### PR TITLE
Migration to API 32 (Android 12)

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,9 @@
+repos:
+  # Websec hook is MANDATORY, DO NOT comment it.
+  - repo: https://github.com/mercadolibre/fury_websec-git-hooks
+    rev: v1.0.0
+    hooks:
+      - id: pre_commit_hook
+        stages: [commit]
+      - id: post_commit_hook
+        stages: [post-commit]

--- a/changelog.md
+++ b/changelog.md
@@ -1,3 +1,7 @@
+# v3.0.0
+## Migrated
+- Migrated to target API 32 (Android 12)
+
 # v2.0.1
 - Fix de location, dejamos de pedirla
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -33,13 +33,13 @@ libraryGroupId=com.mercadolibre.android.device
 # IMPORTANT: We're using http://semver.org/ for all Android projects, please remember to follow this convention.
 # IMPORTANT: The version will be THE SAME for all modules.
 # For libraryVersion do NOT add a qualifier to this version like LOCAL/EXPERIMENTAL (it'll be added automatically!)
-libraryVersion=2.0.1
+libraryVersion=3.0.0
 
 ##################################################################################
 # Project setup
 ##################################################################################
 minApiLevel=16
-maxApiLevel=28
+maxApiLevel=32
 gradleBuildTools=3.3.2
 staticAnalysis=2.6.12
 androidBuildTools=28.0.3

--- a/testapp/src/main/AndroidManifest.xml
+++ b/testapp/src/main/AndroidManifest.xml
@@ -20,7 +20,8 @@
             android:label="@string/app_name"
             android:theme="@style/AppTheme.NoActionBar">
         </activity>
-        <activity android:name=".DeviceDummy">
+        <activity android:name=".DeviceDummy"
+            android:exported="true" >
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />
 


### PR DESCRIPTION
<br><h2>  This Pull Request migrated to [API 32 (Android 12)](https://sites.google.com/mercadolibre.com/mobile/gu%C3%ADas-y-problemas/gu%C3%ADas-de-migraci%C3%B3n/migraci%C3%B3n-api-32-android).</h2>If used the libraries:<br>- androidx.work:work-runtime:2.1 --> 2.7.0<br>- androidx.browser:browser:1.0.0 --> 1.4.0<br>- com.google.android.gms:play-services-analytics:17.0.0 --> 17.0.1<br>- androidx.core:core / core-ktx:1.3.2 --> 1.6.0<br>these must be updated to migrate to Android 12, these libraries generate a breaking change, we must wait until the date they are enabled.(ENABLE LIBS)![image](https://user-images.githubusercontent.com/96055139/186246732-4f900fc9-ac57-4b3d-b706-92ad62268e8e.png)<br>- Please merge this PR if everything is green :white_check_mark:. <br>- If you have any problems or queries, contact the [Platform Update](https://meli.slack.com/archives/C03S5L8SLES)